### PR TITLE
https://github.com/Atmosphere/nettosphere/issues/23

### DIFF
--- a/server/src/main/java/org/atmosphere/nettosphere/Config.java
+++ b/server/src/main/java/org/atmosphere/nettosphere/Config.java
@@ -97,7 +97,7 @@ public class Config {
         private int port = 8080;
         private final Map<String, String> initParams = new HashMap<String, String>();
         private final Map<String, AtmosphereHandler> handlers = new HashMap<String, AtmosphereHandler>();
-        private Class<? extends WebSocketProtocol> webSocketProtocol;
+        private Class<? extends WebSocketProtocol> webSocketProtocol = SimpleHttpProtocol.class;
 
         private Class<Broadcaster> broadcasterClass;
         private BroadcasterFactory broadcasterFactory;

--- a/server/src/main/java/org/atmosphere/nettosphere/SimpleHttpProtocol.java
+++ b/server/src/main/java/org/atmosphere/nettosphere/SimpleHttpProtocol.java
@@ -1,0 +1,194 @@
+/*
+* Copyright 2012 Jeanfrancois Arcand
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+package org.atmosphere.nettosphere;
+
+import org.atmosphere.cpr.ApplicationConfig;
+import org.atmosphere.cpr.AtmosphereConfig;
+import org.atmosphere.cpr.AtmosphereRequest;
+import org.atmosphere.cpr.AtmosphereResourceImpl;
+import org.atmosphere.cpr.FrameworkConfig;
+import org.atmosphere.websocket.WebSocket;
+import org.atmosphere.websocket.WebSocketProcessor;
+import org.atmosphere.websocket.WebSocketProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Like the {@link org.atmosphere.cpr.AsynchronousProcessor} class, this class is responsible for dispatching WebSocket messages to the
+ * proper {@link org.atmosphere.websocket.WebSocket} implementation by wrapping the Websocket message's bytes within
+ * an {@link javax.servlet.http.HttpServletRequest}.
+ * <p/>
+ * The content-type is defined using {@link org.atmosphere.cpr.ApplicationConfig#WEBSOCKET_CONTENT_TYPE} property
+ * The method is defined using {@link org.atmosphere.cpr.ApplicationConfig#WEBSOCKET_METHOD} property
+ * <p/>
+ *
+ * @author Jeanfrancois Arcand
+ */
+public class SimpleHttpProtocol implements WebSocketProtocol, Serializable {
+
+    private static final Logger logger = LoggerFactory.getLogger(SimpleHttpProtocol.class);
+    private String contentType = "text/plain";
+    private String methodType = "POST";
+    private String delimiter = "@@";
+    private boolean destroyable;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(AtmosphereConfig config) {
+        String contentType = config.getInitParameter(ApplicationConfig.WEBSOCKET_CONTENT_TYPE);
+        if (contentType == null) {
+            contentType = "text/plain";
+        }
+        this.contentType = contentType;
+
+        String methodType = config.getInitParameter(ApplicationConfig.WEBSOCKET_METHOD);
+        if (methodType == null) {
+            methodType = "POST";
+        }
+        this.methodType = methodType;
+
+        String delimiter = config.getInitParameter(ApplicationConfig.WEBSOCKET_PATH_DELIMITER);
+        if (delimiter == null) {
+            delimiter = "@@";
+        }
+        this.delimiter = delimiter;
+
+        String s = config.getInitParameter(ApplicationConfig.RECYCLE_ATMOSPHERE_REQUEST_RESPONSE);
+        if (s != null && Boolean.valueOf(s)) {
+            destroyable = true;
+        } else {
+            destroyable = false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<AtmosphereRequest> onMessage(WebSocket webSocket, String d) {
+        AtmosphereResourceImpl resource = (AtmosphereResourceImpl) webSocket.resource();
+        if (resource == null) {
+            logger.trace("The WebSocket has been closed before the message was processed.");
+            return null;
+        }
+        String pathInfo = resource.getRequest().getPathInfo();
+        String requestURI = resource.getRequest().getRequestURI();
+
+        if (d.startsWith(delimiter)) {
+            int delimiterLength = delimiter.length();
+            int bodyBeginIndex = d.indexOf(delimiter, delimiterLength);
+            if (bodyBeginIndex != -1) {
+                pathInfo = d.substring(delimiterLength, bodyBeginIndex);
+                requestURI += pathInfo;
+                d = d.substring(bodyBeginIndex + delimiterLength);
+            }
+        }
+
+        Map<String,Object> m = new HashMap<String, Object>();
+        m.put(FrameworkConfig.WEBSOCKET_SUBPROTOCOL, FrameworkConfig.SIMPLE_HTTP_OVER_WEBSOCKET);
+        // Propagate the original attribute to WebSocket message.
+        m.putAll(resource.getRequest().attributes());
+
+        List<AtmosphereRequest> list = new ArrayList<AtmosphereRequest>();
+
+        // We need to create a new AtmosphereRequest as WebSocket message may arrive concurrently on the same connection.
+        list.add(new AtmosphereRequest.Builder()
+                .request(resource.getRequest())
+                .method(methodType)
+                .contentType(contentType)
+                .body(d)
+                .attributes(m)
+                .pathInfo(pathInfo)
+                .requestURI(requestURI)
+                .destroyable(destroyable)
+                .headers(resource.getRequest().headersMap())
+                .session(resource.session())
+                .build());
+
+        return list;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<AtmosphereRequest> onMessage(WebSocket webSocket, byte[] d, final int offset, final int length) {
+    	
+    	//Converting to a string and delegating to onMessage(WebSocket webSocket, String d) causes issues because the binary data may not be a valid string.
+    	 AtmosphereResourceImpl resource = (AtmosphereResourceImpl) webSocket.resource();
+         if (resource == null) {
+             logger.trace("The WebSocket has been closed before the message was processed.");
+             return null;
+         }
+         String pathInfo = resource.getRequest().getPathInfo();
+         String requestURI = resource.getRequest().getRequestURI();
+
+
+         Map<String,Object> m = new HashMap<String, Object>();
+         m.put(FrameworkConfig.WEBSOCKET_SUBPROTOCOL, FrameworkConfig.SIMPLE_HTTP_OVER_WEBSOCKET);
+         // Propagate the original attribute to WebSocket message.
+         m.putAll(resource.getRequest().attributes());
+
+         List<AtmosphereRequest> list = new ArrayList<AtmosphereRequest>();
+
+         // We need to create a new AtmosphereRequest as WebSocket message may arrive concurrently on the same connection.
+         list.add(new AtmosphereRequest.Builder()
+                 .request(resource.getRequest())
+                 .method(methodType)
+                 .contentType(contentType)
+                 .body(d, offset, length)
+                 .attributes(m)
+                 .pathInfo(pathInfo)
+                 .requestURI(requestURI)
+                 .destroyable(destroyable)
+                 .headers(resource.getRequest().headersMap())
+                 .session(resource.session())
+                 .build());
+
+         return list;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onOpen(WebSocket webSocket) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onClose(WebSocket webSocket) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onError(WebSocket webSocket, WebSocketProcessor.WebSocketException t) {
+        logger.warn(t.getMessage() + " Status {} Message {}", t.response().getStatus(), t.response().getStatusMessage());
+    }
+}
+


### PR DESCRIPTION
Added support for BinaryWebSocketFrame to NettyAtmosphereHandler.handleWebSocketFrame

Please bear in mind that I know almost nothing about atmosphere, so this is unlikely to be an optimal solution, but it seems to be working for me in simple tests.

Notes/Observations:
- I had to override SimpleHttpProtocol.onMessage(WebSocket webSocket, byte[] d, final int offset, final int length) from atmosphere to prevent data being converted to string. My gut feeling is that this should be applied to atmosphere, but there may be a reason for the existing behaviour that I don't understand.
- DefaultBroadcaster.push in atmosphere has some code to do with delayed broadcasts that looks like it is expecting a string rather than binary data. I didn't tackle this.
- I had to configure the host with ApplicationConfig.WEBSOCKET_BINARY_WRITE=true

Hope this is useful.
