### PR TITLE
Set the contentLength on the AtmosphereRequest.

### DIFF
--- a/server/src/main/java/org/atmosphere/nettosphere/NettyAtmosphereHandler.java
+++ b/server/src/main/java/org/atmosphere/nettosphere/NettyAtmosphereHandler.java
@@ -259,6 +259,7 @@ public class NettyAtmosphereHandler extends HttpStaticFileServerHandler {
         final String base = getBaseUri(request);
         final URI requestUri = new URI(base.substring(0, base.length() - 1) + request.getUri());
         String ct = request.getHeaders("Content-Type").size() > 0 ? request.getHeaders("Content-Type").get(0) : "text/plain";
+        long cl = HttpHeaders.getContentLength(request);
         String method = request.getMethod().getName();
 
         String queryString = requestUri.getQuery();
@@ -308,6 +309,7 @@ public class NettyAtmosphereHandler extends HttpStaticFileServerHandler {
                 .headers(getHeaders(request))
                 .method(method)
                 .contentType(ct)
+                .contentLength(cl)
                 .destroyable(false)
                 .attributes(attributes)
                 .servletPath(config.mappingPath())


### PR DESCRIPTION
Hi JeanFrancois

the `contentLength` is not correctly reported from the `AtmosphereRequest` as `createAtmosphereRequest` in the `NettyAtmosphereHandler` has no means of setting it (it is always 0, stemming from `NoOpsRequest`, I think). There is no `HttpServletRequest` object it could set on the `Builder.request` field. I would thus suggest to :
- introduce a `contentLength` field in the `Builder` (see my [complementing pull request in Atmosphere](https://github.com/Atmosphere/atmosphere/pull/999)) , with a defensive extension to the `getContentLength()` method of `AtmosphereRequest`.
- and change `createAtmosphereRequest` to retrieve the contentLength from the headers and set the newly introduced `Builder` field for `contentLength`.

This is only a proposal, maybe there is a more elegant way to have the  `AtmosphereRequest` reflect the proper content length.

Cheers, Christian.
