### PR TITLE
Update HttpStaticFileServerHandler.java

### DIFF
--- a/server/src/main/java/org/atmosphere/nettosphere/HttpStaticFileServerHandler.java
+++ b/server/src/main/java/org/atmosphere/nettosphere/HttpStaticFileServerHandler.java
@@ -333,6 +333,10 @@ public class HttpStaticFileServerHandler extends SimpleChannelUpstreamHandler {
 
         if (dot > 0) {
             String ext = substr.substring(dot + 1);
+            int queryString = ext.indexOf("?");
+            if (queryString>0){
+                ext.substring(0, queryString);
+            }
             String contentType = MimeType.get(ext, defaultContentType);
             response.addHeader(HttpHeaders.Names.CONTENT_TYPE, contentType);
         } else {


### PR DESCRIPTION
Sometimes static files are requested with a query string, with timestamps for instance, leading to wrong mime types. (error encountered with ckeditor 4.3.2 and nettosphere 2.1.0)
