### PR TITLE
Change BridgeRuntime initialization sequence to have all config.initParams() taken into account.

### DIFF
--- a/server/src/main/java/org/atmosphere/nettosphere/BridgeRuntime.java
+++ b/server/src/main/java/org/atmosphere/nettosphere/BridgeRuntime.java
@@ -132,25 +132,6 @@ public class BridgeRuntime extends HttpStaticFileServerHandler {
         }
 
         framework.setAtmosphereDotXmlPath(config.configFile());
-        framework.setAsyncSupport(new NettyCometSupport(framework.getAtmosphereConfig()) {
-            @Override
-            public Action suspended(AtmosphereRequest request, AtmosphereResponse response) throws IOException, ServletException {
-                Action a = super.suspended(request, response);
-                if (framework.getAtmosphereConfig().isSupportSession()) {
-                    AtmosphereResource r = request.resource();
-                    HttpSession s = request.getSession(true);
-                    if (s != null) {
-                        sessions.put(r.uuid(), request.getSession(true));
-                    }
-                }
-                return a;
-            }
-
-            @Override
-            public String toString() {
-                return "NettoSphereAsyncSupport";
-            }
-        });
 
         try {
             if (config.broadcasterFactory() != null) {
@@ -212,6 +193,27 @@ public class BridgeRuntime extends HttpStaticFileServerHandler {
         } catch (ServletException e) {
             throw new RuntimeException(e);
         }
+        
+        framework.setAsyncSupport(new NettyCometSupport(framework.getAtmosphereConfig()) {
+            @Override
+            public Action suspended(AtmosphereRequest request, AtmosphereResponse response) throws IOException, ServletException {
+                Action a = super.suspended(request, response);
+                if (framework.getAtmosphereConfig().isSupportSession()) {
+                    AtmosphereResource r = request.resource();
+                    HttpSession s = request.getSession(true);
+                    if (s != null) {
+                        sessions.put(r.uuid(), request.getSession(true));
+                    }
+                }
+                return a;
+            }
+
+            @Override
+            public String toString() {
+                return "NettoSphereAsyncSupport";
+            }
+        });
+        
         suspendTimer = new ScheduledThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
         webSocketProcessor = WebSocketProcessorFactory.getDefault().getWebSocketProcessor(framework);
 


### PR DESCRIPTION
Heya Jeanfrancois

with the current implementation of BridgeRuntime not all initParams are taken into account on starting up Nettosphere. We hit the issue on trying to configure a custom endpoint mapper through

``` java
config.initParams().put(ApplicationConfig.ENDPOINT_MAPPER, "com.yo.DirectEndpointMapper"); 
```

Cheers, Christian.
