### PR TITLE
Backport HTTP header fix to 2.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
                 <scope>test</scope>
                 <classifier>jdk15</classifier>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>1.10.19</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -56,6 +56,11 @@
             <scope>test</scope>
             <classifier>jdk15</classifier>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/server/src/main/java/org/atmosphere/nettosphere/ChannelWriter.java
+++ b/server/src/main/java/org/atmosphere/nettosphere/ChannelWriter.java
@@ -34,8 +34,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public abstract class ChannelWriter extends AtmosphereInterceptorWriter {
     protected final static Logger logger = LoggerFactory.getLogger(StreamWriter.class);
     protected final static String END = Integer.toHexString(0);
-    protected final static byte[] CHUNK_DELIMITER = "\r\n".getBytes();
-    protected final static byte[] ENDCHUNK = (END + "\r\n\r\n").getBytes();
+    protected static final String CRLF = "\r\n";
+    protected final static byte[] CHUNK_DELIMITER = CRLF.getBytes();
+    protected final static byte[] ENDCHUNK = (END + CRLF + CRLF).getBytes();
 
     protected final Channel channel;
     protected final AtomicBoolean doneProcessing = new AtomicBoolean(false);
@@ -131,23 +132,22 @@ public abstract class ChannelWriter extends AtmosphereInterceptorWriter {
                 .append(response.getStatus())
                 .append(" ")
                 .append(response.getStatusMessage())
-                .append("\n");
+                .append(CRLF);
 
         Map<String, String> headers = response.headers();
         String contentType = response.getContentType();
 
-        b.append("Content-Type").append(":").append(headers.get("Content-Type") == null ? contentType : headers.get("Content-Type")).append("\n");
+        b.append("Content-Type").append(":").append(headers.get("Content-Type") == null ? contentType : headers.get("Content-Type")).append(CRLF);
         if (contentLength != -1) {
-            b.append("Content-Length").append(":").append(contentLength).append("\n");
+            b.append("Content-Length").append(":").append(contentLength).append(CRLF);
         }
 
         for (String s : headers.keySet()) {
             if (!s.equalsIgnoreCase("Content-Type")) {
-                b.append(s).append(":").append(headers.get(s)).append("\n");
+                b.append(s).append(":").append(headers.get(s)).append(CRLF);
             }
         }
-        b.deleteCharAt(b.length() - 1);
-        b.append("\r\n\r\n");
+        b.append(CRLF);
         return b.toString();
     }
 

--- a/server/src/test/java/org/atmosphere/nettosphere/ChannelWriterTest.java
+++ b/server/src/test/java/org/atmosphere/nettosphere/ChannelWriterTest.java
@@ -1,0 +1,123 @@
+package org.atmosphere.nettosphere;
+
+import org.atmosphere.cpr.AsyncIOWriter;
+import org.atmosphere.cpr.AtmosphereResponse;
+import org.jboss.netty.channel.Channel;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+public class ChannelWriterTest {
+
+    public static final HashMap<String, String> EMPTY_HEADERS = new HashMap<String, String>();
+
+    private Channel channelMock;
+    private ChannelWriter sut;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        channelMock = mock(Channel.class);
+        sut = new ChannelWriter(channelMock, true, false) {
+            @Override
+            public AsyncIOWriter asyncWrite(AtmosphereResponse response, byte[] data, int offset, int length) throws IOException {
+                throw new RuntimeException("Not implemented for test.");
+            }
+        };
+    }
+
+    @Test
+    public void testHeaders() throws Exception {
+        AtmosphereResponse response = setupResponse(EMPTY_HEADERS);
+        int contentLength = -1;
+
+        String result = sut.constructStatusAndHeaders(response, contentLength);
+
+        assertEquals("HTTP/1.1 200 OK\r\n" +
+            "Content-Type:text/plain\r\n" +
+            "\r\n", result);
+
+        verifyInteractions(response);
+    }
+
+    @Test
+    public void testHeadersWithLength() throws Exception {
+        AtmosphereResponse response = setupResponse(EMPTY_HEADERS);
+        int contentLength = 10;
+
+        String result = sut.constructStatusAndHeaders(response, contentLength);
+
+        assertEquals("HTTP/1.1 200 OK\r\n" +
+            "Content-Type:text/plain\r\n" +
+            "Content-Length:" + contentLength + "\r\n" +
+            "\r\n", result);
+
+        verifyInteractions(response);
+    }
+
+    @Test
+    public void testCustomHeaders() throws Exception {
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("X-Custom-Header", "value");
+
+        AtmosphereResponse response = setupResponse(headers);
+        int contentLength = 100;
+
+        String result = sut.constructStatusAndHeaders(response, contentLength);
+
+        assertEquals("HTTP/1.1 200 OK\r\n" +
+            "Content-Type:text/plain\r\n" +
+            "Content-Length:" + contentLength + "\r\n" +
+            "X-Custom-Header:value\r\n" +
+            "\r\n", result);
+
+        verifyInteractions(response);
+    }
+
+    @Test
+    public void testCustomContentType() throws Exception {
+        String contentType = "application/json";
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Content-Type", contentType);
+        headers.put("X-Custom-Header", "value");
+
+        AtmosphereResponse response = setupResponse(headers);
+        int contentLength = 100;
+
+        String result = sut.constructStatusAndHeaders(response, contentLength);
+
+        assertEquals("HTTP/1.1 200 OK\r\n" +
+            "Content-Type:" + contentType + "\r\n" +
+            "Content-Length:" + contentLength + "\r\n" +
+            "X-Custom-Header:value\r\n" +
+            "\r\n", result);
+
+        verifyInteractions(response);
+    }
+
+    private AtmosphereResponse setupResponse(Map<String, String> headers) {
+        AtmosphereResponse response = mock(AtmosphereResponse.class);
+        when(response.getStatus()).thenReturn(200);
+        when(response.getStatusMessage()).thenReturn("OK");
+        when(response.getContentType()).thenReturn("text/plain");
+        when(response.headers()).thenReturn(headers);
+        return response;
+    }
+
+    private void verifyInteractions(AtmosphereResponse response) {
+        verify(response).getStatus();
+        verify(response).getStatusMessage();
+        verify(response).getContentType();
+        verify(response).headers();
+        verifyNoMoreInteractions(channelMock, response);
+    }
+
+}


### PR DESCRIPTION
This is the same fix as #98 with the tests from #99 , just applied to the 2.2 branch which we also still use.