### PR TITLE
Revert "wasync AHC 2.1 upgrade fixes"

### DIFF
--- a/server/src/main/java/org/atmosphere/nettosphere/BridgeRuntime.java
+++ b/server/src/main/java/org/atmosphere/nettosphere/BridgeRuntime.java
@@ -415,7 +415,7 @@ public class BridgeRuntime extends HttpStaticFileServerHandler {
         byte[] body = null;
         if (binaryData.isReadable()) {
             body = new byte[binaryData.readableBytes()];
-            binaryData.copy().readBytes(body);
+            binaryData.readBytes(body);
         }
         if (frame instanceof CloseWebSocketFrame) {
             ctx.channel().write(frame).addListener(ChannelFutureListener.CLOSE);
@@ -557,7 +557,7 @@ public class BridgeRuntime extends HttpStaticFileServerHandler {
                     ByteBuf b = FullHttpRequest.class.cast(messageEvent).content();
                     if (b.isReadable()) {
                         body = new byte[b.readableBytes()];
-                        b.copy().readBytes(body);
+                        b.readBytes(body);
                     }
                 }
 


### PR DESCRIPTION
Reverts Atmosphere/nettosphere#127

I think we should wait with this as @seamusmac says himself. I don't understand what this commit fixes at all on reflecting on the changes.